### PR TITLE
Update Combine-PRs workflow

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -15,6 +15,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # pin@v2.1.0
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
       - name: combine-prs
-        id: combine-prs
         uses: github/combine-prs@v4.1.0
+        with:
+          github_token: ${{ steps.generate-token.outputs.token }}
+          labels: combined-pr,dependencies


### PR DESCRIPTION
This PR updates the `combine-prs` workflow to use a GitHub App token so that it can run CI